### PR TITLE
Add notebook_fileserver.py to scripts directory

### DIFF
--- a/scripts/notebook_fileserver.py
+++ b/scripts/notebook_fileserver.py
@@ -1,0 +1,15 @@
+from flask import Flask, render_template, send_from_directory, request
+import jinja2
+import json
+import IPython.html
+import os
+
+static = os.path.abspath(os.path.dirname(__file__)) + '/example-notebooks'
+
+app = Flask(
+    __name__,
+    static_folder=static,
+)
+
+if __name__ == '__main__':
+    app.run(debug=True, port=5001)


### PR DESCRIPTION
Add a basic notebook server to the `scripts/` directory so we can use the same notebooks for testing local and remote nbdiff.
